### PR TITLE
Stats Page

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "web-vitals": "^0.2.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "export HTTPS=true ; export HOST=local.zooniverse.org ; react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,6 @@ import './App.css'
 import { Router, Route } from 'react-router-dom'
 import { Grommet } from 'grommet'
 import { observer } from 'mobx-react'
-import apiClient from 'panoptes-client/lib/api-client'
 
 import { mergedTheme } from './theme'
 import AppContext from './stores'

--- a/src/components/Stats.js
+++ b/src/components/Stats.js
@@ -1,27 +1,51 @@
 import React from 'react'
-import { Box } from 'grommet'
+import { Box, Heading, Text } from 'grommet'
 import { observer } from 'mobx-react'
 import apiClient from 'panoptes-client/lib/api-client'
 
 import AppContext from 'stores'
 
+const ITEMS_PER_PAGE = 20  // Panoptes default
+
 function Stats () {
   const store = React.useContext(AppContext)
   
-  React.useEffect(() => {
-    apiClient.get('/project_preferences', {}).then(projectPreferences => {
-    
-      console.log('+++ project_preferences', projectPreferences)
+  const [projPrefs, setProjPrefs] = React.useState([])
+  
+  function fetchProjPrefs (page = 1, results = []) {
+    apiClient.get('/project_preferences', { page, page_size: ITEMS_PER_PAGE })
+    .then(items => {
+      
+      const updatedResults = [...results, ...items]
+      if (items.length >= ITEMS_PER_PAGE) {
+        fetchProjPrefs(page + 1, updatedResults)
+      } else {
+        finishFetch(updatedResults)
+      }
     })
-    
-    
+    .catch(err => {
+      console.error(err)
+    })
+  }
+  
+  function finishFetch (results) {
+    console.log('+++ FINISHED')
+    setProjPrefs(results)
+  }
+  
+  React.useEffect(() => {
+    console.log('+++ INITIATE')
+    fetchProjPrefs()
   }, [store])
   
   if (!store.auth.user) return null
   
   return (
     <Box>
-      STATS
+      <Heading use='h2'>Stats</Heading>
+      <Box>
+        <Text>Projects participated in: {projPrefs.length}</Text>
+      </Box>
     </Box>
   )
 }

--- a/src/components/Stats.js
+++ b/src/components/Stats.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Box } from 'grommet'
+import { observer } from 'mobx-react'
+import apiClient from 'panoptes-client/lib/api-client'
+
+import AppContext from 'stores'
+
+function Stats () {
+  const store = React.useContext(AppContext)
+  
+  React.useEffect(() => {
+    apiClient.get('/project_preferences', {}).then(projectPreferences => {
+    
+      console.log('+++ project_preferences', projectPreferences)
+    })
+    
+    
+  }, [store])
+  
+  if (!store.auth.user) return null
+  
+  return (
+    <Box>
+      STATS
+    </Box>
+  )
+}
+
+export { Stats }
+export default observer(Stats)

--- a/src/components/Stats.js
+++ b/src/components/Stats.js
@@ -1,16 +1,18 @@
 import React from 'react'
-import { Box, Heading, Text } from 'grommet'
+import { Anchor, Box, Heading, Table, TableBody, TableCell as TC, TableHeader, TableRow as TR, Text } from 'grommet'
 import { observer } from 'mobx-react'
 import apiClient from 'panoptes-client/lib/api-client'
 
 import AppContext from 'stores'
 
 const ITEMS_PER_PAGE = 20  // Panoptes default
+const ESTIMATED_CLASSIFICATIONS_PER_HOUR = 50
 
 function Stats () {
   const store = React.useContext(AppContext)
   
   const [projPrefs, setProjPrefs] = React.useState([])
+  const [stats, setStats] = React.useState({})
   
   function fetchProjPrefs (page = 1, results = []) {
     apiClient.get('/project_preferences', { page, page_size: ITEMS_PER_PAGE })
@@ -30,7 +32,19 @@ function Stats () {
   
   function finishFetch (results) {
     console.log('+++ FINISHED')
+    console.log(results)
+    
+    const totalClassifications = results.reduce((total, pref) => (
+      total + (parseInt(pref.activity_count) || 0)
+    ), 0)
+    
+    const totalHours = totalClassifications / ESTIMATED_CLASSIFICATIONS_PER_HOUR
+    
     setProjPrefs(results)
+    setStats({
+      totalClassifications,
+      totalHours,
+    })
   }
   
   React.useEffect(() => {
@@ -44,8 +58,37 @@ function Stats () {
     <Box>
       <Heading use='h2'>Stats</Heading>
       <Box>
-        <Text>Projects participated in: {projPrefs.length}</Text>
+        <Text size='large'>
+          Projects participated in: <b>{projPrefs.length}</b>
+        </Text>
+        <Text size='large'>
+          Total Classifications: <b>{stats.totalClassifications}</b>
+        </Text>
+        <Text size='large'>
+          Estimated Time Spent: <b>{stats.totalHours}</b> hours (assuming an average of {ESTIMATED_CLASSIFICATIONS_PER_HOUR} classifications per hour)
+        </Text>
+        <Text>
+          See the <Anchor href='https://blog.zooniverse.org/2020/03/26/fulfilling-service-hour-requirements-through-zooniverse/' target='blank'>Zooniverse blog</Anchor> for more details.
+        </Text>
       </Box>
+      <Table size='xsmall'>
+        <TableHeader>
+          <TR>
+            <TC>Project ID</TC>
+            <TC>Classifications</TC>
+            <TC>Most Recent Participation</TC>
+          </TR>
+        </TableHeader>
+        <TableBody>
+          {projPrefs.map(pref => (
+            <TR>
+              <TC>{pref.id}</TC>
+              <TC>{pref.activity_count}</TC>
+              <TC>{pref.updated_at}</TC>
+            </TR>
+          ))}
+        </TableBody>
+      </Table>
     </Box>
   )
 }

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -3,6 +3,7 @@ import { Box, Button, Text, } from 'grommet'
 import { observer } from 'mobx-react'
 
 import AppContext from 'stores'
+import Stats from 'components/Stats'
 
 function HomePage () {
   const store = React.useContext(AppContext)
@@ -31,6 +32,7 @@ function HomePage () {
           </>
         )}
       </Box>
+      <Stats />
     </Box>
   )
 }


### PR DESCRIPTION
## PR Overview

- Stats page added: (it's parked at the home page for now, sorry)
  - An overview of the user's activities can now be shown. The data is on par with the data from the Zooniverse.org PFE home page (logged in version)
  - An estimate of the user's activities, in term of time spent, can now be shown.
- Changed dev domain from `http://localhost:3000` to `https://local.zooniverse.org:3000` to overcome CORS issues.